### PR TITLE
Special-case the handling of DB Cluster- and DB Instance-level metrics in RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ to fix if it would help anyone.
 
 An important detail to be aware of is that CloudWatch metrics are generally
 unlike prometheus metrics (dimensions are less like labels and more like oddly
-named directories.)  For the most part this is not a huge problem, but for
-DynamoDB Indexes we have to append `_index` to the metric to prevent collisions
-if you are scraping table level and index level metrics.
+named directories.)  For the most part this is not a huge problem, though there
+are caveats:
+
+* for DynamoDB Indexes, we have to append `_index` to the metric to prevent
+  collisions if you are scraping table-level and index-level metrics;
+* for RDS DB Clusters and DB Instances, we have to append `_cluster` and
+  `_instance` respectively to prevent collisions when scraping cluster-level
+  and instance-level metrics.
 
 ## Advanced Customization
 

--- a/pkg/exportcloudwatch/config.go
+++ b/pkg/exportcloudwatch/config.go
@@ -41,10 +41,42 @@ func (e *ExportConfig) isDynamodDBIndexMetric() bool {
 	return false
 }
 
+func (e *ExportConfig) isRDSDBClusterMetric() bool {
+	if e.Namespace != "AWS/RDS" {
+		return false
+	}
+
+	for _, d := range e.Dimensions {
+		if d == "DBClusterIdentifier" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (e *ExportConfig) isRDSDBInstanceMetric() bool {
+	if e.Namespace != "AWS/RDS" {
+		return false
+	}
+
+	for _, d := range e.Dimensions {
+		if d == "DBInstanceIdentifier" {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (e *ExportConfig) String(i int) string {
 	var base string
 	if e.isDynamodDBIndexMetric() {
 		base = e.Name + "Index" + e.Statistics[i]
+	} else if e.isRDSDBClusterMetric() {
+		base = e.Name + "Cluster" + e.Statistics[i]
+	} else if e.isRDSDBInstanceMetric() {
+		base = e.Name + "Instance" + e.Statistics[i]
 	} else {
 		base = e.Name + e.Statistics[i]
 	}


### PR DESCRIPTION
Specifically, with a configuration like such:

```toml
[[exportconfigs]]

   namespace = "AWS/RDS"
   name = "CPUUtilization"
   dimensionsMatch   = { DBInstanceIdentifier = "..."    }
   dimensions = ["DBInstanceIdentifier"]
   statistics = ["Average"]

[[exportconfigs]]

   namespace = "AWS/RDS"
   name = "CPUUtilization"
   dimensionsMatch   = { DBClusterIdentifier = "..."    }
   dimensions = ["DBClusterIdentifier" , "Role"]
   statistics = ["Average"]
```

the previous behavior would have generated the following error:

```
Namespace=AWS/RDS Name=CPUUtilization: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "aws_rds_utilization_average", help: "", constLabels: {}, variableLabels: [cluster_identifier role]} has different label names or a different help string
```

The patch would allow the configuration above, with the caveat that metrics are now renamed from, e.g., `aws_rds_utilization_average{instance_identifier="shared"}` to `aws_rds_utilization_instance_average{instance_identifier="shared"}`. Similarly, a cluster would have `_cluster` instead of `_instance`.