### PR TITLE
Add StatDefault to configuration.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"regexp"
 
 	"github.com/ZipRecruiter/cloudwatching/pkg/exportcloudwatch"
@@ -12,6 +13,8 @@ type exportConfig struct {
 	Dimensions, Statistics []string
 
 	DimensionsMatch, DimensionsNoMatch map[string]string
+
+	StatDefault string
 }
 
 type configuration struct {
@@ -33,6 +36,16 @@ func (c *configuration) Validate() error {
 			Statistics:        raw.Statistics,
 			DimensionsMatch:   make(map[string]*regexp.Regexp, len(raw.DimensionsMatch)),
 			DimensionsNoMatch: make(map[string]*regexp.Regexp, len(raw.DimensionsNoMatch)),
+		}
+
+		if raw.StatDefault == "Prior" {
+			c.exportConfigs[i].StatDefault = exportcloudwatch.Prior
+		} else if raw.StatDefault == "Zero" {
+			c.exportConfigs[i].StatDefault = exportcloudwatch.Zero
+		} else if raw.StatDefault == "NaN" {
+			c.exportConfigs[i].StatDefault = exportcloudwatch.NaN
+		} else if raw.StatDefault != "" {
+			return errors.New("StatDefault must be one of Prior, Zero, or NaN")
 		}
 
 		for k, v := range raw.DimensionsMatch {

--- a/pkg/exportcloudwatch/config.go
+++ b/pkg/exportcloudwatch/config.go
@@ -10,6 +10,20 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// StatDefaultType describes how to deal with a stat that has no value
+type StatDefaultType int
+
+const (
+	// Prior leaves the stat set to its prior value; this is the default
+	Prior StatDefaultType = iota
+
+	// Zero will set the stat to 0
+	Zero
+
+	// NaN will set the stat to not-a-number
+	NaN
+)
+
 // ExportConfig describes which cloudwatch metrics we want to export.  Make sure
 // you call Validate.
 type ExportConfig struct {
@@ -22,6 +36,9 @@ type ExportConfig struct {
 
 	// Both of these filter the metrics based on the values of the dimension
 	DimensionsMatch, DimensionsNoMatch map[string]*regexp.Regexp
+
+	// StatDefault determines the default value for a stat if no value is read
+	StatDefault StatDefaultType
 
 	// each collector maps to the statistic in the same location
 	collectors []*prometheus.GaugeVec

--- a/pkg/exportcloudwatch/config_test.go
+++ b/pkg/exportcloudwatch/config_test.go
@@ -41,15 +41,17 @@ func TestValidate(t *testing.T) {
 					DimensionsNoMatch: map[string]*regexp.Regexp{
 						"QueueName": regexp.MustCompile("^bar"),
 					},
+					StatDefault: Zero,
 				},
 			},
 
 			out: []ExportConfig{
 				{
-					Namespace:  "AWS/SQS",
-					Name:       "ApproximateAgeOfOldestMessage",
-					Dimensions: []string{"Alpha", "QueueName"},
-					Statistics: []string{"Maximum"},
+					Namespace:   "AWS/SQS",
+					Name:        "ApproximateAgeOfOldestMessage",
+					Dimensions:  []string{"Alpha", "QueueName"},
+					Statistics:  []string{"Maximum"},
+					StatDefault: Zero,
 				},
 			},
 		},


### PR DESCRIPTION
StatDefault may be set to one of the following values:

Prior - The stat starts at 0 and is never reset. If the stat is has no value in CloudWatch, the prior value is reported. This was the existing behavior before this was introduced, and is now the default behavior unless otherwise configured.

Zero - The stat starts at 0 and resets back to zero if the stat has no value in CloudWatch.

NaN - The stat starts as not-a-number (NaN) and resets back to NaN if the stat has no value in CloudWatch.