### PR TITLE
Fix up metric name conversion

### DIFF
--- a/pkg/exportcloudwatch/config.go
+++ b/pkg/exportcloudwatch/config.go
@@ -97,7 +97,7 @@ func (e *ExportConfig) String(i int) string {
 	} else {
 		base = e.Name + e.Statistics[i]
 	}
-	base = strings.ToLower(e.Namespace) + "_" + pascalToUnderScores(base)
+	base = strings.ToLower(e.Namespace) + "_" + cloudWatchToPrometheusName(base)
 	base = strings.ReplaceAll(base, "/", "_")
 
 	return base
@@ -146,7 +146,7 @@ func (e *ExportConfig) Validate() error {
 	e.collectors = make([]*prometheus.GaugeVec, len(e.Statistics))
 	aliasedDimensions := make([]string, len(e.Dimensions))
 	for j, d := range e.Dimensions {
-		aliasedDimensions[j] = pascalToUnderScores(d)
+		aliasedDimensions[j] = cloudWatchToPrometheusName(d)
 	}
 
 	for j := range e.Statistics {

--- a/pkg/exportcloudwatch/strings.go
+++ b/pkg/exportcloudwatch/strings.go
@@ -5,15 +5,55 @@ import (
 	"strings"
 )
 
-var re = regexp.MustCompile("[A-Z][a-z0-9_]+")
+var (
+	nonAlphaCharsRE   = regexp.MustCompile("[^a-zA-Z0-9]")
+	pascalCaseWordsRE = regexp.MustCompile("([A-Z0-9]*)([a-z]*)")
+)
 
 func pascalToUnderScores(in string) string {
-	found := re.FindAllString(in, -1)
+	words := make([]string, 0)
 
-	ret := strings.ToLower(found[0])
-	for _, s := range found[1:] {
-		ret += "_" + strings.ToLower(s)
+	// CloudWatch metrics follow a "SequenceOfPascalCaseWords" naming scheme, for the most part - so
+	// first split up the input string by non-alphanumeric characters first…
+	for _, chunk := range nonAlphaCharsRE.Split(in, -1) {
+		// …and then detect Pascal-case-y words.
+		for _, captures := range pascalCaseWordsRE.FindAllStringSubmatch(chunk, -1) {
+			word := captures[0]
+			upperCasePrefix := captures[1]
+			lowerCaseSuffix := captures[2]
+
+			// we need to match a sequence of uppercase/number followed by a sequence of lowercase -
+			// either (but not both) may be absent, but handling the absence of both purely in regexp
+			// is less clear than just tolerating it in the FindAllStringSubmatch results, detecting
+			// that scenario, and moving on - both with the algorithm and our lives
+			if len(word) == 0 {
+				continue
+			}
+
+			// sometimes a word is an acronym, such as "TCP"…
+			isAcronym := len(upperCasePrefix) >= 2
+
+			// …which can be pluralized (eg. "CPUs", "LCUs")
+			isPluralized := lowerCaseSuffix == "s"
+
+			// …or concatenated with another Pascal-case word (eg. "ADAnomaly")
+			hasAdjacentWord := lowerCaseSuffix != ""
+
+			if isAcronym && !isPluralized && hasAdjacentWord {
+				// if we see a non-plural acronym that's concatenated with another word,
+				// we treat everything but the last uppercase character we found as part
+				// of the acronym:
+				words = append(words, upperCasePrefix[:len(upperCasePrefix)-1])
+
+				// …and the last uppercase character as the first letter
+				// of the next word:
+				words = append(words, upperCasePrefix[len(upperCasePrefix)-1:]+lowerCaseSuffix)
+			} else {
+				// in all other situations, it's just a single word, so just use that
+				words = append(words, word)
+			}
+		}
 	}
 
-	return ret
+	return strings.ToLower(strings.Join(words, "_"))
 }

--- a/pkg/exportcloudwatch/strings.go
+++ b/pkg/exportcloudwatch/strings.go
@@ -10,7 +10,7 @@ var (
 	pascalCaseWordsRE = regexp.MustCompile("([A-Z0-9]*)([a-z]*)")
 )
 
-func pascalToUnderScores(in string) string {
+func cloudWatchToPrometheusName(in string) string {
 	words := make([]string, 0)
 
 	// CloudWatch metrics follow a "SequenceOfPascalCaseWords" naming scheme, for the most part - so

--- a/pkg/exportcloudwatch/strings.go
+++ b/pkg/exportcloudwatch/strings.go
@@ -5,12 +5,25 @@ import (
 	"strings"
 )
 
+var re = regexp.MustCompile("[A-Z][a-z0-9_]+")
+
+func cloudWatchToPrometheusNameV0(in string) string {
+	found := re.FindAllString(in, -1)
+
+	ret := strings.ToLower(found[0])
+	for _, s := range found[1:] {
+		ret += "_" + strings.ToLower(s)
+	}
+
+	return ret
+}
+
 var (
 	nonAlphaCharsRE   = regexp.MustCompile("[^a-zA-Z0-9]")
 	pascalCaseWordsRE = regexp.MustCompile("([A-Z0-9]*)([a-z]*)")
 )
 
-func cloudWatchToPrometheusName(in string) string {
+func cloudWatchToPrometheusNameV1(in string) string {
 	words := make([]string, 0)
 
 	// CloudWatch metrics follow a "SequenceOfPascalCaseWords" naming scheme, for the most part - so

--- a/pkg/exportcloudwatch/strings_test.go
+++ b/pkg/exportcloudwatch/strings_test.go
@@ -38,7 +38,7 @@ func (tw *testWriter) Write(payload []byte) (int, error) {
 	return len(payload), nil
 }
 
-func TestPascalToUnderScores(t *testing.T) {
+func TestCloudWatchToPrometheusName(t *testing.T) {
 	for _, test := range stringTests {
 		test := test
 
@@ -46,9 +46,9 @@ func TestPascalToUnderScores(t *testing.T) {
 			tw := &testWriter{t: t}
 			log.SetOutput(tw)
 
-			gotOutput := pascalToUnderScores(test.input)
+			gotOutput := cloudWatchToPrometheusName(test.input)
 			if gotOutput != test.expectedOutput {
-				t.Fatalf("pascalToUnderScores(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
+				t.Fatalf("cloudWatchToPrometheusName(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
 			}
 		})
 	}

--- a/pkg/exportcloudwatch/strings_test.go
+++ b/pkg/exportcloudwatch/strings_test.go
@@ -1,0 +1,55 @@
+package exportcloudwatch
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+type stringTest struct {
+	input          string
+	expectedOutput string
+}
+
+var stringTests []stringTest = []stringTest{
+	{input: "AllErrors", expectedOutput: "all_errors"},
+	{input: "2xx", expectedOutput: "2xx"},
+	{input: "4xxErrors", expectedOutput: "4xx_errors"},
+	{input: "DescribeDeliveryStream.Requests", expectedOutput: "describe_delivery_stream_requests"},
+	{input: "DesyncMitigationMode_NonCompliant_Request_Count", expectedOutput: "desync_mitigation_mode_non_compliant_request_count"},
+	{input: "ClusterStatus.red", expectedOutput: "cluster_status_red"},
+	{input: "ActiveFlowCount_TCP", expectedOutput: "active_flow_count_tcp"},
+	{input: "ADAnomalyDetectorsIndexStatusIndexExists", expectedOutput: "ad_anomaly_detectors_index_status_index_exists"},
+	{input: "ADAnomalyDetectorsIndexStatus.red", expectedOutput: "ad_anomaly_detectors_index_status_red"},
+	{input: "ConsumedLCUs", expectedOutput: "consumed_lcus"},
+	{input: "ConsumedLCUs_TCP", expectedOutput: "consumed_lcus_tcp"},
+	{input: "AuroraDMLRejectedMasterFull", expectedOutput: "aurora_dml_rejected_master_full"},
+	{input: "CPUAllocated", expectedOutput: "cpu_allocated"},
+	{input: "dfs.FSNamesystem.PendingReplicationBlocks", expectedOutput: "dfs_fs_namesystem_pending_replication_blocks"},
+	{input: "HTTPCode_ELB_5XX", expectedOutput: "http_code_elb_5xx"},
+}
+
+type testWriter struct {
+	t *testing.T
+}
+
+func (tw *testWriter) Write(payload []byte) (int, error) {
+	tw.t.Log(string(bytes.TrimSuffix(payload, []byte("\n"))))
+	return len(payload), nil
+}
+
+func TestPascalToUnderScores(t *testing.T) {
+	for _, test := range stringTests {
+		test := test
+
+		t.Run(test.input, func(t *testing.T) {
+			tw := &testWriter{t: t}
+			log.SetOutput(tw)
+
+			gotOutput := pascalToUnderScores(test.input)
+			if gotOutput != test.expectedOutput {
+				t.Fatalf("pascalToUnderScores(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
+			}
+		})
+	}
+}

--- a/pkg/exportcloudwatch/strings_test.go
+++ b/pkg/exportcloudwatch/strings_test.go
@@ -11,7 +11,12 @@ type stringTest struct {
 	expectedOutput string
 }
 
-var stringTests []stringTest = []stringTest{
+var stringTestsV0 []stringTest = []stringTest{
+	{input: "AllErrors", expectedOutput: "all_errors"},
+	{input: "DescribeDeliveryStream.Requests", expectedOutput: "describe_delivery_stream_requests"},
+}
+
+var stringTestsV1 []stringTest = []stringTest{
 	{input: "AllErrors", expectedOutput: "all_errors"},
 	{input: "2xx", expectedOutput: "2xx"},
 	{input: "4xxErrors", expectedOutput: "4xx_errors"},
@@ -38,17 +43,33 @@ func (tw *testWriter) Write(payload []byte) (int, error) {
 	return len(payload), nil
 }
 
-func TestCloudWatchToPrometheusName(t *testing.T) {
-	for _, test := range stringTests {
+func TestCloudWatchToPrometheusNameV0(t *testing.T) {
+	for _, test := range stringTestsV0 {
 		test := test
 
 		t.Run(test.input, func(t *testing.T) {
 			tw := &testWriter{t: t}
 			log.SetOutput(tw)
 
-			gotOutput := cloudWatchToPrometheusName(test.input)
+			gotOutput := cloudWatchToPrometheusNameV0(test.input)
 			if gotOutput != test.expectedOutput {
-				t.Fatalf("cloudWatchToPrometheusName(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
+				t.Fatalf("cloudWatchToPrometheusNameV0(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
+			}
+		})
+	}
+}
+
+func TestCloudWatchToPrometheusNameV1(t *testing.T) {
+	for _, test := range stringTestsV1 {
+		test := test
+
+		t.Run(test.input, func(t *testing.T) {
+			tw := &testWriter{t: t}
+			log.SetOutput(tw)
+
+			gotOutput := cloudWatchToPrometheusNameV1(test.input)
+			if gotOutput != test.expectedOutput {
+				t.Fatalf("cloudWatchToPrometheusNameV1(%q) != %q (got %q instead)", test.input, test.expectedOutput, gotOutput)
 			}
 		})
 	}


### PR DESCRIPTION
Some metrics have substrings from the original metric name omitted from the resulting Prometheus metric - for example, both `ClusterStatus.red` and `ClusterStatus.yellow` become `aws_es_cluster_status`, which results in duplicate metric registration and a panic.  This PR includes tests for various CloudWatch metric names, plus a new algorithm for splitting them up into words and recombining them.